### PR TITLE
Refactor api so all config falls under the deployable extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v0.2.0-SNAPSHOT - unreleased
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
     - Api stays mostly the same, deploy and install tasks are still valid
-- **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.primaryPublication { artifact task }` blocks
+- **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.mainArtifact { artifact task }` blocks
 - Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
 - **[breaking]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
 - **[breaking]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
+- **[breaking]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scopes are no longer used and we now offer a `clear()` method.
 
 
 ### v0.1.12 - released 5/28/2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.2.0-SNAPSHOT - unreleased
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
-- **[BREAKING]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.mainArtifact { artifact task }` blocks
+- **[BREAKING]** Customizing deployable artifacts has changed, we now use the `deployable.publication.main { artifact mainOutputTask }` and `deployable.publication.amend { artifact additionalTask }` blocks
 - **[BREAKING]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
 - **[BREAKING]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scope priorities are no longer used. We also added a `clear()` method.
 - Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### v0.2.0-SNAPSHOT - unreleased
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
-- **[BREAKING]** Customizing deployable artifacts has changed, we now use the `deployable.publication.main { artifact mainOutputTask }` and `deployable.publication.amend { artifact additionalTask }` blocks
+- **[BREAKING]** Customizing deployable artifacts (formerly via maven's `archives {}` block has changed, we now use the `deployable.publication.main { artifact mainOutputTask }` and `deployable.publication.amend { artifact additionalTask }` blocks. See [README for more info](README.md#customize-published-artifacts)
 - **[BREAKING]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
-- **[BREAKING]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scope priorities are no longer used. We also added a `clear()` method.
-- Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
+- **[BREAKING]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scope priorities are no longer used. We also added a `clear()` method. See [README for more info](README.md#customize-dependencies)
+- Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`. See [README for more info](README.md#customize-pom-as-xml)
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
     - Api stays mostly the same, deploy and install tasks are still valid
 - **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }`
-- Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.withPomXml { }`
+- Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
 - **[breaking]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v0.2.0-SNAPSHOT - unreleased
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
     - Api stays mostly the same, deploy and install tasks are still valid
-- **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }`
+- **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.primaryPublication { artifact task }` blocks
 - Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
 - **[breaking]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ### v0.2.0-SNAPSHOT - unreleased
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin
-    - Api stays mostly the same, deploy and install tasks are still valid
-- **[breaking]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.mainArtifact { artifact task }` blocks
+- **[BREAKING]** Customizing deployable artifacts has changed, we now use the `deployable.publication { artifact task }` and `deployable.mainArtifact { artifact task }` blocks
+- **[BREAKING]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
+- **[BREAKING]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scope priorities are no longer used. We also added a `clear()` method.
 - Add config block to customize pom as xml (after deployable has done its initial setup) `deployable.pom.withXml { }`
 - Add new plugin `com.episode6.hackit.deployable.gradle-plugin` to workaround java-gradle-plugins build in publish config
-- **[breaking]** Stop providing default values for repo urls. If no urls are specified, no repo will be set up.
-- **[breaking]** Moved `mavenDependencies {}` block to `deployable.pom.dependencyConfigurations {}`. Api remains mostly the same, but scopes are no longer used and we now offer a `clear()` method.
 
 
 ### v0.1.12 - released 5/28/2018

--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ In each deployable sub-module apply one of the plugins to `build.gradle`
 // to deploy a JAR
 apply plugin: 'com.episode6.hackit.deployable.jar'
 
-// to deploy an AAR
+// to deploy an Android AAR
 apply plugin: 'com.episode6.hackit.deployable.aar'
+
+// to deploy a JAR with kotlin support
+// (requires org.jetbrains.dokka:dokka-gradle-plugin on the classpath)
+apply plugin: 'com.episode6.hackit.deployable.kt.jar'
+
+// to deploy an Android AAR with kotlin support
+// (requires org.jetbrains.dokka:dokka-android-gradle-plugin on the classpath)
+apply plugin: 'com.episode6.hackit.deployable.kt.aar'
 ```
 
 If you need kotlin support, you must also include dokka on your buildscript classpath (for javadoc support) and use one of the `kt` plugins instead
@@ -42,9 +50,6 @@ buildscript {
   repositories { jcenter() }
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-
-    // deployable's kt plugin applies the dokka plugin, so it must be
-    // included on the buildscript classpath
     classpath "com.episode6.hackit.deployable:deployable:$deployableVersion"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
   }
@@ -59,7 +64,10 @@ Similarly for a kotlin-android library...
 // deployable AAR with Kotlin support
 
 buildscript {
-  repositories { jcenter() }
+  repositories {
+    jcenter()
+    google()
+  }
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ dependencies {
 }
 ```
 
-To map dependencies of extra configurations use the `mavenDependencies` method...
+To map dependencies of extra configurations to the maven pom use the `deployable.pom.dependencyConfigurations` block...
 ```groovy
 configurations {
     someCompileConfig
@@ -171,7 +171,7 @@ configurations {
     someProvidedOptionalConfig
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
     // map with configuration reference
     map configurations.someCompileConfig, "compile"
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ deployable {
 }
 ```
 
+#### Customize POM as XML
+If you need to make some additional changes to the pom xml output at the last-mile, use the `deployable.pom.withXml {}` block
+```groovy
+deployable {
+    pom {
+        withXml {
+            appendNode("someNewNode")
+        }
+    }
+}
+```
+
 ### Why does it exist?
 This was my first gradle plugin and groovy project so it is still rough around a few edges. The main goal here was to abstract away as much of the boilerplate of publishing a maven-deployable library as possible, and make it quick and painless to create and deploy new open-source libraries. Having an abstraction-layer on top of 3rd party tools also grants the flexibility to adapt and should enable future support for more types of repos without requiring changes to individual project configuration.
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ deployable {
 ```
 
 ### Why does it exist?
-This is my first gradle plugin and groovy project so it may be rough around the edges. There are probably better tools out there for your open source libraries, but this will be building block for upcoming episode6 open source projects.
+This was my first gradle plugin and groovy project so it is still rough around a few edges. The main goal here was to abstract away as much of the boilerplate of publishing a maven-deployable library as possible, and make it quick and painless to create and deploy new open-source libraries. Having an abstraction-layer on top of 3rd party tools also grants the flexibility to adapt and should enable future support for more types of repos without requiring changes to individual project configuration.
 
 ### License
 MIT: https://github.com/episode6/deployable/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Deployable for Gradle
 =====================
 Gradle plugins to ease the pain of deploying jars and aars to maven repositories.
 
-## Usage
+## Setup
 Add Deployable to the classpath in your root `build.gradle`
 ```groovy
 buildscript {
@@ -42,6 +42,7 @@ apply plugin: 'com.episode6.hackit.deployable.kt.jar'
 apply plugin: 'com.episode6.hackit.deployable.kt.aar'
 ```
 
+#### Kotlin Setup
 If you need kotlin support, you must also include dokka on your buildscript classpath (for javadoc support) and use one of the `kt` plugins instead
 ```groovy
 // deployable JAR with Kotlin support
@@ -81,12 +82,14 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.episode6.hackit.deployable.kt.aar'
 ```
 
+#### Groovy Setup
 If this is a groovy project you'll want to pair the deployable.jar plugin with the groovydocs addon
 ```groovy
 apply plugin: 'com.episode6.hackit.deployable.jar'
 apply plugin: 'com.episode6.hackit.deployable.addon.groovydocs'
 ```
 
+#### gradle.properties setup
 Add the common pom elements to your root `gradle.properties`
 ```
 deployable.pom.description=Gradle plugins to ease the pain of creating deployable jars and aars
@@ -113,7 +116,9 @@ signing.keyId=<keyId>
 signing.password=<keyPassword>
 signing.secretKeyRingFile=<pathToKeyringFile>
 ```
+**WARNING**: DON'T PUT PASSWORDS IN YOUR REPO! The above file belongs in your home directory at `~/.gradle/gradle.properties`
 
+#### build.gradle setup
 Most of deployable's properties can alternatively be set or overridden directly in your `build.gradle`
 ```groovy
 apply plugin: 'java-library'
@@ -147,9 +152,11 @@ deployable {
 }
 ```
 
+#### Deploy
 Finally, deploy using
 `./gradlew publish` or the new deploy alias `./gradlew deploy`
 
+#### Default Dependency Mapping
 Deployable includes built-in mapping for dependencies declared in `api` and `implementation` configurations (into the dependency section of the maven pom output). We also add `mavenOptional`, `mavenProvided` and `mavenProvidedOptional` configurations which will also be mapped automatically.
 ```groovy
 dependencies {
@@ -170,6 +177,7 @@ dependencies {
 }
 ```
 
+#### Customize Dependencies
 To map dependencies of other configurations to the maven pom use the `deployable.pom.dependencyConfigurations` block...
 ```groovy
 configurations {
@@ -208,6 +216,7 @@ dependencies {
 }
 ```
 
+#### Customize Published Artifacts
 To modify or amend the actual publication or included artifacts (i.e. what jars will actually be signed and published), use the `deployable.publishing` block.
 ```groovy
 deployable {

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
@@ -14,7 +14,7 @@ class DeployableAarPlugin implements Plugin<Project> {
     DeployablePlugin deployablePlugin = project.plugins.apply(DeployablePlugin)
     deployablePlugin.pomPackaging = "aar"
 
-    project.deployable.primaryPublication {
+    project.deployable.mainArtifact {
       artifact project.bundleRelease
     }
 

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
@@ -14,7 +14,7 @@ class DeployableAarPlugin implements Plugin<Project> {
     DeployablePlugin deployablePlugin = project.plugins.apply(DeployablePlugin)
     deployablePlugin.pomPackaging = "aar"
 
-    project.deployable.mainArtifact {
+    project.deployable.publication.main {
       artifact project.bundleRelease
     }
 
@@ -48,7 +48,7 @@ class DeployableAarPlugin implements Plugin<Project> {
       }
 
       if (variant.name == "release") {
-        project.deployable.publication {
+        project.deployable.publication.amend {
           artifact javadocJarTask
           artifact sourcesJarTask
         }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableAarPlugin.groovy
@@ -14,7 +14,7 @@ class DeployableAarPlugin implements Plugin<Project> {
     DeployablePlugin deployablePlugin = project.plugins.apply(DeployablePlugin)
     deployablePlugin.pomPackaging = "aar"
 
-    project.deployable.publication {
+    project.deployable.primaryPublication {
       artifact project.bundleRelease
     }
 

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
@@ -23,10 +23,14 @@ class DeployableJarPlugin implements Plugin<Project> {
       classifier = 'sources'
     }
 
-    project.deployable.publication {
-      artifact project.jar
-      artifact project.javadocJar
-      artifact project.sourcesJar
+    project.deployable {
+      primaryPublication {
+        artifact project.jar
+      }
+      publication {
+        artifact project.javadocJar
+        artifact project.sourcesJar
+      }
     }
   }
 }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
@@ -24,7 +24,7 @@ class DeployableJarPlugin implements Plugin<Project> {
     }
 
     project.deployable {
-      primaryPublication {
+      mainArtifact {
         artifact project.jar
       }
       publication {

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableJarPlugin.groovy
@@ -23,11 +23,11 @@ class DeployableJarPlugin implements Plugin<Project> {
       classifier = 'sources'
     }
 
-    project.deployable {
-      mainArtifact {
+    project.deployable.publication {
+      main {
         artifact project.jar
       }
-      publication {
+      amend {
         artifact project.javadocJar
         artifact project.sourcesJar
       }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
@@ -34,7 +34,7 @@ class DeployableKotlinAarPlugin implements Plugin<Project> {
     }
 
     project.deployable {
-      primaryPublication {
+      mainArtifact {
         artifact project.bundleRelease
       }
       publication {

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
@@ -33,9 +33,13 @@ class DeployableKotlinAarPlugin implements Plugin<Project> {
       from project.dokka
     }
 
-    project.deployable.publication {
-      artifact project.bundleRelease
-      artifact project.javadocJar
+    project.deployable {
+      primaryPublication {
+        artifact project.bundleRelease
+      }
+      publication {
+        artifact project.javadocJar
+      }
     }
 
     project.android.libraryVariants.all { variant ->

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinAarPlugin.groovy
@@ -33,11 +33,11 @@ class DeployableKotlinAarPlugin implements Plugin<Project> {
       from project.dokka
     }
 
-    project.deployable {
-      mainArtifact {
+    project.deployable.publication {
+      main {
         artifact project.bundleRelease
       }
-      publication {
+      amend {
         artifact project.javadocJar
       }
     }
@@ -57,7 +57,7 @@ class DeployableKotlinAarPlugin implements Plugin<Project> {
       }
 
       if (variant.name == "release") {
-        project.deployable.publication {
+        project.deployable.publication.amend {
           artifact sourcesJarTask
         }
       }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
@@ -34,10 +34,14 @@ class DeployableKotlinJarPlugin implements Plugin<Project> {
       classifier = 'sources'
     }
 
-    project.deployable.publication {
-      artifact project.jar
-      artifact project.javadocJar
-      artifact project.sourcesJar
+    project.deployable {
+      primaryPublication {
+        artifact project.jar
+      }
+      publication {
+        artifact project.javadocJar
+        artifact project.sourcesJar
+      }
     }
   }
 }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
@@ -35,7 +35,7 @@ class DeployableKotlinJarPlugin implements Plugin<Project> {
     }
 
     project.deployable {
-      primaryPublication {
+      mainArtifact {
         artifact project.jar
       }
       publication {

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableKotlinJarPlugin.groovy
@@ -34,11 +34,11 @@ class DeployableKotlinJarPlugin implements Plugin<Project> {
       classifier = 'sources'
     }
 
-    project.deployable {
-      mainArtifact {
+    project.deployable.publication {
+      main {
         artifact project.jar
       }
-      publication {
+      amend {
         artifact project.javadocJar
         artifact project.sourcesJar
       }

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployablePlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployablePlugin.groovy
@@ -23,17 +23,13 @@ class DeployablePlugin implements Plugin<Project> {
     project.plugins.apply(MavenPublishPlugin)
     project.plugins.apply(SigningPlugin)
 
-    mavenConfig = new MavenConfigurator(project: project)
-    mavenConfig.prepare()
-
-    project.ext.mavenDependencies = { Closure closure ->
-      mavenConfig.mapConfigs(closure)
-    }
-
     DeployablePluginExtension deployable = project.extensions.create(
         "deployable",
         DeployablePluginExtension,
         project)
+
+    mavenConfig = new MavenConfigurator(project: project, deployable: deployable)
+    mavenConfig.prepare()
 
     project.task("validateDeployable", type: DeployableValidationTask) {
       description = "Validates this project's deployable properties to ensure it can generate a valid pom."
@@ -53,7 +49,7 @@ class DeployablePlugin implements Plugin<Project> {
     }
 
     project.afterEvaluate {
-      mavenConfig.configure(deployable, pomPackaging)
+      mavenConfig.configure(pomPackaging)
       // TODO fix tasks
       project.tasks.findByPath("publishMavenArtifactsPublicationToMavenRepository")?.dependsOn project.validateDeployable
       project.tasks.findByPath("publishMavenArtifactsPublicationToMavenLocal")?.dependsOn project.validateDeployable

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployablePlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployablePlugin.groovy
@@ -5,7 +5,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.plugins.signing.SigningPlugin
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 
 /**
  * Base deployable plugin. It is not referenced directly in gradle, but applied by either the jar or aar plugin

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -78,10 +78,10 @@ class MavenConfigurator {
             }
           }
 
-          configureWithClosure(it, deployable.mainArtifact)
-          deployable.publicationClosures.each { closure ->
+          deployable.publication.additionalConfigurationClosures.each { closure ->
             configureWithClosure(it, closure)
           }
+          configureWithClosure(it, deployable.publication.main)
 
           pom.withXml {
             def rootPom = asNode()

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -1,11 +1,8 @@
 package com.episode6.hackit.deployable
 
 import com.episode6.hackit.deployable.extension.DeployablePluginExtension
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.publish.maven.MavenPublication
 
 /**
@@ -178,7 +175,7 @@ class MavenConfigurator {
   }
 
   private static void configurePublicationPomXml(Node rootPom, DeployablePluginExtension deployable) {
-    deployable.pomXmlClosures.each { closure ->
+    deployable.pom.xmlClosures.each { closure ->
       closure.setDelegate(rootPom)
       closure.setResolveStrategy(Closure.DELEGATE_FIRST)
       closure.call()

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -110,6 +110,7 @@ class MavenConfigurator {
             }
           }
 
+          configureWithClosure(it, deployable.primaryPublication)
           configurePublicationArtifacts(it, deployable)
 
           pom.withXml {
@@ -168,17 +169,19 @@ class MavenConfigurator {
 
   private static void configurePublicationArtifacts(MavenPublication publication, DeployablePluginExtension deployable) {
     deployable.publicationClosures.each { closure ->
-      closure.setDelegate(publication)
-      closure.setResolveStrategy(Closure.DELEGATE_FIRST)
-      closure.call()
+      configureWithClosure(publication, closure)
     }
   }
 
   private static void configurePublicationPomXml(Node rootPom, DeployablePluginExtension deployable) {
     deployable.pom.xmlClosures.each { closure ->
-      closure.setDelegate(rootPom)
-      closure.setResolveStrategy(Closure.DELEGATE_FIRST)
-      closure.call()
+      configureWithClosure(rootPom, closure)
     }
+  }
+
+  private static void configureWithClosure(Object delegate, Closure closure) {
+    closure.setDelegate(delegate)
+    closure.setResolveStrategy(Closure.DELEGATE_FIRST)
+    closure.call()
   }
 }

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -110,7 +110,7 @@ class MavenConfigurator {
             }
           }
 
-          configureWithClosure(it, deployable.primaryPublication)
+          configureWithClosure(it, deployable.mainArtifact)
           configurePublicationArtifacts(it, deployable)
 
           pom.withXml {

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -78,10 +78,10 @@ class MavenConfigurator {
             }
           }
 
+          configureWithClosure(it, deployable.publication.main)
           deployable.publication.additionalConfigurationClosures.each { closure ->
             configureWithClosure(it, closure)
           }
-          configureWithClosure(it, deployable.publication.main)
 
           pom.withXml {
             def rootPom = asNode()

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
@@ -1,5 +1,6 @@
 package com.episode6.hackit.deployable
 
+import com.episode6.hackit.deployable.extension.DeployablePluginExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.*
@@ -7,25 +8,13 @@ import org.gradle.api.artifacts.*
 class MavenDependencyConfigurator {
 
   Project project
-
-  private Map<String, CustomConfigMapping> mappedConfigs = new HashMap<>()
-
-  void putConfigMapping(String gradleConfig, String mavenScope, boolean optional = false) {
-    CustomConfigMapping mapping = new CustomConfigMapping(gradleConfig: gradleConfig,
-        mavenScope: mavenScope,
-        optional: optional)
-    mappedConfigs.put(mapping.gradleConfig, mapping)
-  }
-
-  void removeConfigMapping(String gradleConfig) {
-    mappedConfigs.remove(gradleConfig)
-  }
+  DeployablePluginExtension deployable
 
   void configureDependencies(Node pomRoot) {
     def depsNode = getDependencyNode(pomRoot)
     depsNode.children.clear() // start with no deps
 
-    mappedConfigs.values().each { mappedConfig ->
+    deployable.pom.dependencyConfigurations.map.values().each { mappedConfig ->
       def config = project.configurations.findByName(mappedConfig.gradleConfig)
       if (config == null) {
         return
@@ -97,12 +86,6 @@ class MavenDependencyConfigurator {
     String group
     String name
     String version
-  }
-
-  private static class CustomConfigMapping {
-    String gradleConfig
-    String mavenScope
-    boolean optional
   }
 
   private interface DepToXmlMapper {

--- a/src/main/groovy/com/episode6/hackit/deployable/addon/GroovyDocAddonPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/addon/GroovyDocAddonPlugin.groovy
@@ -16,7 +16,7 @@ class GroovyDocAddonPlugin implements Plugin<Project>{
       from project.groovydoc
     }
 
-    project.deployable.publication {
+    project.deployable.publication.amend {
       artifact project.groovydocJar
     }
   }

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -77,6 +77,7 @@ class DeployablePluginExtension extends NestablePluginExtension {
     }
   }
 
+  Closure primaryPublication = {}
   final List<Closure> publicationClosures = new LinkedList<>()
 
   PomExtension pom

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -135,16 +135,38 @@ class DeployablePluginExtension extends NestablePluginExtension {
     }
   }
 
-  Closure mainArtifact = {}
-  final List<Closure> publicationClosures = new LinkedList<>()
+  static class PublicationExtension extends NestablePluginExtension {
+
+    Closure main = {}
+    final List<Closure> additionalConfigurationClosures = new LinkedList<>()
+
+    PublicationExtension(NestablePluginExtension parent) {
+      super(parent, "publication")
+    }
+
+    void main(Closure closure) {
+      main = closure
+    }
+
+    void amend(Closure closure) {
+      additionalConfigurationClosures.add(closure)
+    }
+
+    void clear() {
+      additionalConfigurationClosures.clear()
+    }
+  }
+
 
   PomExtension pom
   NexusExtension nexus
+  PublicationExtension publication
 
   DeployablePluginExtension(Project project) {
     super(project, "deployable")
     pom = new PomExtension(this)
     nexus = new NexusExtension(this)
+    publication = new PublicationExtension(this)
   }
 
   PomExtension pom(Closure closure) {
@@ -155,8 +177,8 @@ class DeployablePluginExtension extends NestablePluginExtension {
     return nexus.applyClosure(closure)
   }
 
-  void publication(Closure closure) {
-    publicationClosures.add(closure)
+  PublicationExtension publication(Closure closure) {
+    return publication.applyClosure(closure)
   }
 
   @Override

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -2,7 +2,6 @@ package com.episode6.hackit.deployable.extension
 
 import com.episode6.hackit.nestable.NestablePluginExtension
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.MavenPublication
 
 /**
  * Deployable plugin extension. Stores/retreives info that is used
@@ -49,6 +48,8 @@ class DeployablePluginExtension extends NestablePluginExtension {
     String description = null
     String url = null
 
+    final List<Closure> xmlClosures = new LinkedList<>()
+
     ScmExtension scm
     LicenseExtension license
     DeveloperExtension developer
@@ -58,6 +59,10 @@ class DeployablePluginExtension extends NestablePluginExtension {
       scm = new ScmExtension(this)
       license = new LicenseExtension(this)
       developer = new DeveloperExtension(this)
+    }
+
+    void withXml(Closure closure) {
+      xmlClosures.add(closure)
     }
   }
 
@@ -72,17 +77,15 @@ class DeployablePluginExtension extends NestablePluginExtension {
     }
   }
 
+  final List<Closure> publicationClosures = new LinkedList<>()
+
   PomExtension pom
   NexusExtension nexus
-  List<Closure> publicationClosures
-  List<Closure> pomXmlClosures
 
   DeployablePluginExtension(Project project) {
     super(project, "deployable")
     pom = new PomExtension(this)
     nexus = new NexusExtension(this)
-    publicationClosures = new LinkedList<>()
-    pomXmlClosures = new LinkedList<>()
   }
 
   PomExtension pom(Closure closure) {
@@ -95,10 +98,6 @@ class DeployablePluginExtension extends NestablePluginExtension {
 
   void publication(Closure closure) {
     publicationClosures.add(closure)
-  }
-
-  void withPomXml(Closure closure) {
-    pomXmlClosures.add(closure)
   }
 
   @Override

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -151,10 +151,6 @@ class DeployablePluginExtension extends NestablePluginExtension {
     void amend(Closure closure) {
       additionalConfigurationClosures.add(closure)
     }
-
-    void clear() {
-      additionalConfigurationClosures.clear()
-    }
   }
 
 

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -48,11 +48,11 @@ class DeployablePluginExtension extends NestablePluginExtension {
     String description = null
     String url = null
 
-    final List<Closure> xmlClosures = new LinkedList<>()
-
     ScmExtension scm
     LicenseExtension license
     DeveloperExtension developer
+
+    final List<Closure> xmlClosures = new LinkedList<>()
 
     PomExtension(NestablePluginExtension parent) {
       super(parent, "pom")

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -77,7 +77,7 @@ class DeployablePluginExtension extends NestablePluginExtension {
     }
   }
 
-  Closure primaryPublication = {}
+  Closure mainArtifact = {}
   final List<Closure> publicationClosures = new LinkedList<>()
 
   PomExtension pom

--- a/src/test/groovy/com/episode6/hackit/deployable/AarIntegrationTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/AarIntegrationTest.groovy
@@ -331,7 +331,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "implementation"
 }
 """
@@ -369,7 +369,7 @@ dependencies {
   mavenOptional 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "mavenOptional"
 }
 """
@@ -407,7 +407,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.implementation, "provided"
 }
 """
@@ -450,7 +450,7 @@ dependencies {
   mavenProvided 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map "mavenProvided", "compile"
 }
 """

--- a/src/test/groovy/com/episode6/hackit/deployable/JarIntegrationTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/JarIntegrationTest.groovy
@@ -353,7 +353,7 @@ dependencies {
   someOtherConfig 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.someConfig, "provided"
   map "someOtherConfig", "compile"
 }
@@ -409,7 +409,7 @@ dependencies {
   someOtherConfig 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   mapOptional configurations.someConfig, "compile"
   mapOptional "someOtherConfig", "provided"
 }
@@ -505,7 +505,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "implementation"
 }
 """
@@ -545,7 +545,7 @@ dependencies {
   mavenOptional 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "mavenOptional"
 }
 """
@@ -585,7 +585,7 @@ dependencies {
   implementation 'org.spockframework:spock-core:1.1-groovy-2.4'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.implementation, "provided"
 }
 """
@@ -630,7 +630,7 @@ dependencies {
   mavenProvidedOptional 'org.spockframework:spock-core:1.1-groovy-2.4'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map "mavenProvidedOptional", "compile"
 }
 """

--- a/src/test/groovy/com/episode6/hackit/deployable/KotlinAarIntegrationTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/KotlinAarIntegrationTest.groovy
@@ -337,7 +337,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "implementation"
 }
 """
@@ -375,7 +375,7 @@ dependencies {
   mavenOptional 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "mavenOptional"
 }
 """
@@ -418,7 +418,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.implementation, "provided"
 }
 """
@@ -466,7 +466,7 @@ dependencies {
   mavenProvided 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map "mavenProvided", "compile"
 }
 """

--- a/src/test/groovy/com/episode6/hackit/deployable/KotlinJarIntegrationTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/KotlinJarIntegrationTest.groovy
@@ -282,7 +282,7 @@ dependencies {
   someOtherConfig 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.someConfig, "provided"
   map "someOtherConfig", "compile"
 }
@@ -334,7 +334,7 @@ dependencies {
   someOtherConfig 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   mapOptional configurations.someConfig, "compile"
   mapOptional "someOtherConfig", "provided"
 }
@@ -430,7 +430,7 @@ dependencies {
   implementation 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "implementation"
 }
 """
@@ -470,7 +470,7 @@ dependencies {
   mavenOptional 'com.episode6.hackit.chop:chop-core:0.1.8'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   unmap "mavenOptional"
 }
 """
@@ -515,7 +515,7 @@ dependencies {
   implementation 'org.spockframework:spock-core:1.1-groovy-2.4'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map configurations.implementation, "provided"
 }
 """
@@ -565,7 +565,7 @@ dependencies {
   mavenProvidedOptional 'org.spockframework:spock-core:1.1-groovy-2.4'
 }
 
-mavenDependencies {
+deployable.pom.dependencyConfigurations {
   map "mavenProvidedOptional", "compile"
 }
 """

--- a/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
@@ -147,7 +147,7 @@ plugins {
 group = '${groupId}'
 version = '${versionName}'
 
-deployable.mainArtifact {
+deployable.publication.main {
 }
 """
 

--- a/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
@@ -127,4 +127,40 @@ deployable {
     "com.snapshot.override.example"  | "snapshotlib" | "0.0.1-SNAPSHOT"
     "com.release.override.example"   | "releaselib"  | "0.0.2"
   }
+
+  def "test override main artifact"(String groupId, String artifactId, String versionName) {
+    given:
+    testProject.rootProjectName = artifactId
+    testProject.createNonEmptyJavaFile("${groupId}.${artifactId}")
+    MavenOutputVerifier mavenOutputVerifier = new MavenOutputVerifier(
+        groupId: groupId,
+        artifactId: artifactId,
+        versionName: versionName,
+        testProject: testProject)
+    testProject.rootGradlePropertiesFile << testProject.testProperties.inGradlePropertiesFormat
+    testProject.rootGradleBuildFile << """
+plugins {
+ id 'java'
+ id 'com.episode6.hackit.deployable.jar'
+}
+
+group = '${groupId}'
+version = '${versionName}'
+
+deployable.mainArtifact {
+}
+"""
+
+    when:
+    def result = testProject.executeGradleTask("deploy")
+
+    then:
+    result.task(":deploy").outcome == TaskOutcome.SUCCESS
+    mavenOutputVerifier.verifyStandardOutputSkipMainArtifact()
+
+    where:
+    groupId                          | artifactId    | versionName
+    "com.snapshot.override.example"  | "snapshotlib" | "0.0.1-SNAPSHOT"
+    "com.release.override.example"   | "releaselib"  | "0.0.2"
+  }
 }

--- a/src/test/groovy/com/episode6/hackit/deployable/testutil/MavenOutputVerifier.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/testutil/MavenOutputVerifier.groovy
@@ -49,6 +49,15 @@ class MavenOutputVerifier {
         verifyJarFile("javadoc")
   }
 
+  boolean verifyStandardOutputSkipMainArtifact(String artifactPackaging = "jar") {
+    return verifyRootMavenMetaData() &&
+        verifyVersionSpecificMavenMetaData() &&
+        verifyPomData() &&
+        verifyMissingJarFile(null, artifactPackaging) &&
+        verifyJarFile("sources") &&
+        verifyJarFile("javadoc")
+  }
+
   boolean verifyRootMavenMetaData() {
     def mavenMetaData = getMavenProjectDir().newFile("maven-metadata.xml").asXml()
 
@@ -196,6 +205,12 @@ class MavenOutputVerifier {
     jar.close()
 
     assert verifySignatureOfFile(jarFile)
+    return true
+  }
+
+  boolean verifyMissingJarFile(String descriptor = null, String extension = "jar") {
+    File jarFile = getArtifactFile(extension, descriptor)
+    assert !jarFile.exists()
     return true
   }
 


### PR DESCRIPTION
Refactor the odd bits of the existing api and bring everything under the deployable extension. New api usage looks like...

```groovy
deployable {
    pom {

        // replaces maveDependencies block
        dependencyConfigurations {
            map "implementation" "compile"
        }

        // modify pom as xml (deferred execution /  last step)
        withXml {
            appenNode("someXmlNode")
        }
    }

    // configure publication via deferred execution
    publication {

        // replace main jar artifact
        main {
            artifact mainJarTask
        }

        // add to publication configuration
        amend {
            artifact extraDocsJar
        }
    }
}
```