### PR TITLE
Fix return type of publication methods for better IJ support

### DIFF
--- a/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -33,7 +33,8 @@ class MavenConfigurator {
   void configure(String pomPackaging) {
     project.configurations {
       compileOnly {
-        extendsFrom(mavenOptional,
+        extendsFrom(
+            mavenOptional,
             mavenProvided,
             mavenProvidedOptional)
       }

--- a/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -3,6 +3,7 @@ package com.episode6.hackit.deployable.extension
 import com.episode6.hackit.nestable.NestablePluginExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.publish.maven.MavenPublication
 
 /**
  * Deployable plugin extension. Stores/retreives info that is used
@@ -144,12 +145,18 @@ class DeployablePluginExtension extends NestablePluginExtension {
       super(parent, "publication")
     }
 
-    void main(Closure closure) {
+    MavenPublication main(Closure closure) {
       main = closure
+      // method return type fools IntelliJ into figuring out the right delegate for this closure,
+      // but we generate the publication and call the closure lazily, so we can't actually return it here
+      return null
     }
 
-    void amend(Closure closure) {
+    MavenPublication amend(Closure closure) {
       additionalConfigurationClosures.add(closure)
+      // method return type fools IntelliJ into figuring out the right delegate for this closure,
+      // but we generate the publication and call the closure lazily, so we can't actually return it here
+      return null
     }
   }
 


### PR DESCRIPTION
It looks like gradle in IntelliJ uses the return type of a plugin method that accepts a closure, to "guess" the delegate that will be applied to that closure. 

This PR updates the return type of `deployable.publication.main` and `deployable.publication.amend` to `MavenPublication`, since that's the delegate we apply to the closures before calling them. However we must return null here, because the publication is created lazily in an afterEvaluate block.