### PR TITLE
Don't fail build of we can't map a dependency

### DIFF
--- a/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
@@ -3,7 +3,10 @@ package com.episode6.hackit.deployable
 import com.episode6.hackit.deployable.extension.DeployablePluginExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.artifacts.*
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.ResolvedDependency
 
 class MavenDependencyConfigurator {
 
@@ -20,7 +23,7 @@ class MavenDependencyConfigurator {
         return
       }
 
-      eachDependency(config) { ModuleDependency unresolvedDep, DepId depId ->
+      eachDependency(config) { DepId depId ->
         def depNode = depsNode.appendNode('dependency')
         depNode.appendNode('groupId', depId.group)
         depNode.appendNode('artifactId', depId.name)
@@ -29,9 +32,9 @@ class MavenDependencyConfigurator {
         if (mappedConfig.optional) {
           depNode.appendNode('optional', true)
         }
-        if (!unresolvedDep.excludeRules.isEmpty()) {
+        if (!depId.unresolved.excludeRules.isEmpty()) {
           def exclusionsNode = depNode.appendNode('exclusions')
-          unresolvedDep.excludeRules.each { exRule ->
+          depId.unresolved.excludeRules.each { exRule ->
             def exNode = exclusionsNode.appendNode('exclusion')
             exNode.appendNode('groupId', exclusionValue(exRule.group))
             exNode.appendNode('artifactId', exclusionValue(exRule.module))
@@ -49,10 +52,12 @@ class MavenDependencyConfigurator {
     def unresolvedDeps = config.dependencies
     def resolvedDeps = getResolvedDeps(config)
 
-    unresolvedDeps.findAll { it instanceof ModuleDependency }.collect { (ModuleDependency) it }.each { unresolvedDep ->
-      def resolvedDep = resolvedDeps.find { unresolvedDep.group == it.moduleGroup && unresolvedDep.name == it.moduleName }
-      def depId = getDepId(unresolvedDep, resolvedDep)
-      mapper.map(unresolvedDep, depId)
+    unresolvedDeps.findAll { it instanceof ModuleDependency }.collect {
+      ModuleDependency unresolvedDep = (ModuleDependency) it
+      ResolvedDependency resolvedDep = resolvedDeps.find { unresolvedDep.group == it.moduleGroup && unresolvedDep.name == it.moduleName }
+      return getDepId(unresolvedDep, resolvedDep)
+    }.each {
+      mapper.map(it)
     }
   }
 
@@ -71,24 +76,25 @@ class MavenDependencyConfigurator {
     }
   }
 
-  private static DepId getDepId(Dependency unresolvedDep, ResolvedDependency resolvedDep) {
+  private static DepId getDepId(ModuleDependency unresolvedDep, ResolvedDependency resolvedDep) {
     if (unresolvedDep instanceof ProjectDependency) {
       Project depProj = unresolvedDep.getDependencyProject()
-      return new DepId(group: depProj.group, name: depProj.name, version: depProj.version)
+      return new DepId(group: depProj.group, name: depProj.name, version: depProj.version, unresolved: unresolvedDep)
     } else if (resolvedDep != null) {
-      return new DepId(group: resolvedDep.moduleGroup, name: resolvedDep.moduleName, version: resolvedDep.moduleVersion)
+      return new DepId(group: resolvedDep.moduleGroup, name: resolvedDep.moduleName, version: resolvedDep.moduleVersion, unresolved: unresolvedDep)
     } else {
       throw new GradleException("Couldn't figure out dependency: ${unresolvedDep}")
     }
   }
 
   private static class DepId {
+    ModuleDependency unresolved
     String group
     String name
     String version
   }
 
   private interface DepToXmlMapper {
-    void map(Dependency unresolvedDep, DepId depId)
+    void map(DepId depId)
   }
 }

--- a/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/MavenDependencyConfigurator.groovy
@@ -1,7 +1,6 @@
 package com.episode6.hackit.deployable
 
 import com.episode6.hackit.deployable.extension.DeployablePluginExtension
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleDependency
@@ -56,7 +55,7 @@ class MavenDependencyConfigurator {
       ModuleDependency unresolvedDep = (ModuleDependency) it
       ResolvedDependency resolvedDep = resolvedDeps.find { unresolvedDep.group == it.moduleGroup && unresolvedDep.name == it.moduleName }
       return getDepId(unresolvedDep, resolvedDep)
-    }.each {
+    }.findAll { it != null }.each {
       mapper.map(it)
     }
   }
@@ -82,9 +81,10 @@ class MavenDependencyConfigurator {
       return new DepId(group: depProj.group, name: depProj.name, version: depProj.version, unresolved: unresolvedDep)
     } else if (resolvedDep != null) {
       return new DepId(group: resolvedDep.moduleGroup, name: resolvedDep.moduleName, version: resolvedDep.moduleVersion, unresolved: unresolvedDep)
-    } else {
-      throw new GradleException("Couldn't figure out dependency: ${unresolvedDep}")
     }
+
+    println "Warning: Deployable skipped mapping dependency: ${unresolvedDep}"
+    return null
   }
 
   private static class DepId {


### PR DESCRIPTION
If we find a dependency we don't know how to handle, print a warning instead of failing the build. This should fix a bug when using gdmc namespaced aliases.