### PR TITLE
Fix bug where gradle-plugin plugin might generate an invalid pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Deployable ChangeLog
 
 ### v0.2.1-SNAPSHOT - unreleased
-
+- Fix bug in `gradle-plugin` plugin
 
 ### v0.2.0-SNAPSHOT - released July 29, 2018
 - Re-write plugin to use `maven-publish` instead of old `maven` plugin

--- a/src/main/groovy/com/episode6/hackit/deployable/DeployableGradlePluginPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/deployable/DeployableGradlePluginPlugin.groovy
@@ -3,7 +3,6 @@ package com.episode6.hackit.deployable
 import com.episode6.hackit.deployable.addon.GroovyDocAddonPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 
 /**
  * Plugin to make gradle plugins deployable
@@ -18,11 +17,11 @@ class DeployableGradlePluginPlugin implements Plugin<Project> {
       apply('java-gradle-plugin')
     }
 
-    // disable the java-gradle-plugin's build in publish tasks
-    project.tasks.withType(PublishToMavenRepository).whenTaskAdded { t ->
-      if (t.name.startsWith("publishPluginMaven")) {
-        t.enabled = false
-      }
+    project.afterEvaluate {
+      // disable the java-gradle-plugin's build in publish tasks
+      project.tasks.findByName("publishPluginMavenPublicationToMavenRepository")?.enabled = false
+      project.tasks.findByName("publishPluginMavenPublicationToMavenLocal")?.enabled = false
+      project.tasks.findByName("generatePomFileForPluginMavenPublication")?.enabled = false
     }
   }
 }


### PR DESCRIPTION
explicitly disable the tasks breaking deployment of gradle plugins