### PR TITLE
Add support for developer email in pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Deployable ChangeLog
 
-### v0.2.2 - released August 6th, 2018
+### v0.2.2 - released August 7th, 2018
 - Add publication params for `includeSources` and `includeDocs`. If unset, default is true, so there should be no need to update existing projects. See [README for more info](README.md#excluding-sources-and-docs)
 - Add plugin publication configuration methods for `amendSources` and `amendDocs`. These configuration steps will be skipped if `includeSources` / `includeDocs` are false (respectively). See [README for more info](README.md#customize-published-artifacts)
 - Add experimental [bintray plugin](buildSrc/src/main/groovy/com/episode6/hackit/deployable/addon/BintrayAddonPlugin.groovy)
+- Add (optional) support for `deployable.pom.developer.email`
 
 ### v0.2.1 - released July 29, 2018
 - Fix bug in `gradle-plugin` plugin

--- a/buildSrc/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
+++ b/buildSrc/src/main/groovy/com/episode6/hackit/deployable/MavenConfigurator.groovy
@@ -72,6 +72,9 @@ class MavenConfigurator {
               developer {
                 id = deployable.pom.developer.id
                 name = deployable.pom.developer.name
+                if (deployable.pom.developer.email != null) {
+                  email = deployable.pom.developer.email
+                }
               }
             }
             scm {

--- a/buildSrc/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
+++ b/buildSrc/src/main/groovy/com/episode6/hackit/deployable/extension/DeployablePluginExtension.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.publish.maven.MavenPublication
  */
 class DeployablePluginExtension extends NestablePluginExtension {
   private static final String[] OPTIONAL_PROPERTIES = [
+      "deployable.pom.developer.email",
       "deployable.nexus.username",
       "deployable.nexus.password",
       "deployable.nexus.releaseRepoUrl",
@@ -44,6 +45,7 @@ class DeployablePluginExtension extends NestablePluginExtension {
     static class DeveloperExtension extends NestablePluginExtension {
       String id
       String name
+      String email
 
       DeveloperExtension(NestablePluginExtension parent) {
         super(parent, "developer")

--- a/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/OverridePropertiesTest.groovy
@@ -43,6 +43,7 @@ deployable {
     developer {
       id "${deployable.pom.developer.id}"
       name "${deployable.pom.developer.name}"
+      email "${deployable.pom.developer.email}"
     }
   }
 
@@ -93,6 +94,7 @@ deployable {
         developer {
           id "DeveloperIdOVERRIDE"
           name "DeveloperNameOVERRIDE"
+          email "TestEmail@Nowhere.com"
         }
       }
 

--- a/src/test/groovy/com/episode6/hackit/deployable/testutil/MavenOutputVerifier.groovy
+++ b/src/test/groovy/com/episode6/hackit/deployable/testutil/MavenOutputVerifier.groovy
@@ -133,6 +133,9 @@ class MavenOutputVerifier {
     assert pom.developers.size() == 1
     assert pom.developers.developer.id.text() == expectedPom.developer.id
     assert pom.developers.developer.name.text() == expectedPom.developer.name
+    if (expectedPom.developer.email != null) {
+      assert pom.developers.developer.email.text() == expectedPom.developer.email
+    }
     assert pom.scm.connection.text() == expectedPom.scm.connection
     assert pom.scm.developerConnection.text() == expectedPom.scm.developerConnection
     assert pom.scm.url.text() == expectedPom.scm.url


### PR DESCRIPTION
Deployable has never had a config option for developer email because it's not a required pom element in MavenCentral. However some like to have it included, so this PR adds support for it.

Was going to wait to merge this into 0.2.3, but it was ready before the release of 0.2.2, so we're merging it right into the release branch.